### PR TITLE
fix(broadens the search for plugins): increases the search space for rafter plugins

### DIFF
--- a/core/rafter/lib/plugins/PluginPathProvider.ts
+++ b/core/rafter/lib/plugins/PluginPathProvider.ts
@@ -30,7 +30,8 @@ export class PluginPathProvider implements IPluginPathProvider {
     } catch (error) {
       this.logger.warn(`Failed to load the package.json for ${pluginName}, trying another approach`);
 
-      const modulesPaths: string[] = findNodeModules({ relative: false });
+      // NOTE: this is pretty heavy handed, but the way npm works the dependencies could be anywhere!
+      const modulesPaths: string[] = require.main?.paths || findNodeModules({ relative: false });
       const packageJsonPaths = modulesPaths.map((modulesPath) => join(modulesPath, pluginName, `package.json`));
       this.logger.debug(`Checking the following node_modules for the package: ${packageJsonPaths.join(', ')}`);
 


### PR DESCRIPTION
In some situations, require/import could not resolve dependencies correctly. In order to combat that,
the search space has been increased to capture all node_modules directories that node has access to.