### PR TITLE
WIP Logger

### DIFF
--- a/core/api/README.md
+++ b/core/api/README.md
@@ -19,14 +19,14 @@ Example structure
   - preStartHooks.ts
   - routes.ts
 - lib
-  - HomeController.ts
+  - HealthController.ts
 - index.ts
 
 #### index.ts
 
 This is the server entry point. Think of this like your `express()` server definition.
 
-You pass in the paths you want to autoload our dependencies from. In the example below all the `./config` files and `./lib/HomeController.ts` will load into the rafter api server.
+You pass in the paths you want to autoload our dependencies from. In the example below all the `./config` files and `./lib/HealthController.ts` will load into the rafter api server.
 
 ```typescript
 import { Server } from '@rafterjs/api';
@@ -50,7 +50,7 @@ async function run(): Promise<void> {
 run();
 ```
 
-#### lib/HomeController.ts
+#### lib/HealthController.ts
 
 One of the benefits of the `@rafterjs/api` is that you can extend the provided `JsonController` and it will handle rendering in a consistent format.
 

--- a/core/api/config/middleware.ts
+++ b/core/api/config/middleware.ts
@@ -4,8 +4,8 @@ export default (): IMiddlewares =>
   new Set<IMiddlewareConfig>([
     'jsonBodyParserMiddleware', // NOTE: jsonBodyParser must come before expressHttpContextMiddleware
     'expressHttpContextMiddleware',
-    'correlationIdMiddleware',
-    'requestLoggerMiddleware',
-    'helmetMiddleware',
-    'cors',
+    // 'correlationIdMiddleware',
+    // 'requestLoggerMiddleware',
+    // 'helmetMiddleware',
+    // 'cors',
   ]);

--- a/core/api/config/plugins.ts
+++ b/core/api/config/plugins.ts
@@ -1,4 +1,5 @@
 import { IPlugin, IPluginsConfig } from 'rafter';
 
 export default (): IPluginsConfig =>
-  new Set<IPlugin>(['@rafterjs/logger-plugin', '@rafterjs/utils', '@rafterjs/cors-plugin']);
+  // new Set<IPlugin>(['@rafterjs/logger-plugin', '@rafterjs/utils', '@rafterjs/cors-plugin']);
+  new Set<IPlugin>(['@rafterjs/utils', '@rafterjs/cors-plugin']);

--- a/core/api/lib/response/JsonRenderer.ts
+++ b/core/api/lib/response/JsonRenderer.ts
@@ -1,19 +1,18 @@
 import { IRequest, IResponse } from 'rafter';
-import { IJsonController } from './IJsonController';
 import { IJsonResponseData } from './IJsonResponse';
 import { JsonErrorResponseDto } from './JsonErrorResponseDto';
 import { JsonResponseDto } from './JsonResponseDto';
-import { JsonRenderer } from './JsonRenderer';
+import { JsonResponseTransformer } from './JsonResponseTransformer';
 
-export abstract class JsonController implements IJsonController {
-  protected constructor(protected readonly jsonRenderer: JsonRenderer) {}
+export class JsonRenderer {
+  protected constructor(protected readonly jsonResponseTransformer: JsonResponseTransformer) {}
 
   public async render<T extends IJsonResponseData>(
     request: IRequest,
     response: IResponse,
     jsonResponseDto: JsonResponseDto<T>,
   ): Promise<void> {
-    return this.jsonRenderer.render(request, response, jsonResponseDto);
+    response.status(jsonResponseDto.status).json(this.jsonResponseTransformer.convert(request, jsonResponseDto));
   }
 
   public async renderError(
@@ -21,6 +20,10 @@ export abstract class JsonController implements IJsonController {
     response: IResponse,
     jsonErrorResponseDto: JsonErrorResponseDto,
   ): Promise<void> {
-    return this.jsonRenderer.renderError(request, response, jsonErrorResponseDto);
+    response
+      .status(jsonErrorResponseDto.status)
+      .json(this.jsonResponseTransformer.convertError(request, jsonErrorResponseDto));
   }
 }
+
+export default JsonRenderer;

--- a/core/api/lib/response/index.ts
+++ b/core/api/lib/response/index.ts
@@ -4,6 +4,7 @@ export * from './IJsonResponse';
 export * from './IJsonResponseTransformer';
 export * from './JsonController';
 export * from './JsonErrorResponseDto';
+export * from './JsonRenderer';
 export * from './JsonResponseDto';
 export * from './JsonResponseTransformer';
 export * from './ResponseDto';

--- a/core/lambda/config/plugins.ts
+++ b/core/lambda/config/plugins.ts
@@ -1,3 +1,3 @@
 import { IPlugin, IPluginsConfig } from 'rafter';
 
-export default (): IPluginsConfig => new Set<IPlugin>(['@rafterjs/logger-plugin', '@rafterjs/utils']);
+export default (): IPluginsConfig => new Set<IPlugin>(['@rafterjs/utils']);

--- a/core/lambda/package.json
+++ b/core/lambda/package.json
@@ -34,11 +34,11 @@
   },
   "homepage": "https://github.com/rafterjs/rafter/tree/master/core/lambda",
   "dependencies": {
-    "@rafterjs/logger-plugin": "^0.8.63",
     "@rafterjs/utils": "^0.8.63",
     "rafter": "^0.8.63"
   },
   "devDependencies": {
+    "@rafterjs/logger-plugin": "^0.8.63",
     "@rafterjs/babel-preset-rafter": "^0.8.63",
     "@rafterjs/eslint-config": "^0.8.63",
     "@rafterjs/test": "^0.8.63"

--- a/core/rafter/lib/plugins/PluginPathProvider.ts
+++ b/core/rafter/lib/plugins/PluginPathProvider.ts
@@ -28,7 +28,7 @@ export class PluginPathProvider implements IPluginPathProvider {
     try {
       validPath = join(dirname(require.resolve(pluginName)), `**`);
     } catch (error) {
-      this.logger.warn(`Failed to load the package.json for ${pluginName}, trying another approach`);
+      this.logger.debug(`Failed to load the package.json for ${pluginName}, trying another approach`);
 
       // NOTE: this is pretty heavy handed, but the way npm works the dependencies could be anywhere!
       const modulesPaths: string[] = require.main?.paths || findNodeModules({ relative: false });
@@ -54,7 +54,7 @@ export class PluginPathProvider implements IPluginPathProvider {
           return pluginPath;
         }
       } catch (error) {
-        this.logger.warn(`Failed to load the package.json from ${path}`);
+        this.logger.debug(`Failed to load the package.json from ${path}`);
       }
     }
   }


### PR DESCRIPTION
Since `@rafterjs/logger` is included by default in `@rajfterjs/api` it would never be properly overridden by loggers either passed into `Server` or as new `logger` plugins. 

I think there's more that can be done about reusing the logger that was passed into rafter instead of autoloading it. I think that will mean ignoring autoloaded loggers and just reusing the passed one. I think we should also allow passing in of a `loggerFactory` into `Server` since many rafter services now switched over to using a `loggerFactory` instead of a `logger`. Might need to explore this further.

I also split out the json renderer so it can be reused in other contexts as it's own dependency